### PR TITLE
chore: Bump up go version for e2e Dockerfile

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,5 +1,5 @@
 # The Dockerfile's resulting image is used in executing Kepler e2e tests on ProwCI
-FROM golang:1.20
+FROM golang:1.21
 
 WORKDIR /workspace
 
@@ -11,9 +11,9 @@ RUN go mod download
 
 # Install kubectl and oc
 RUN curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz \
-    && tar -xvzf oc.tar.gz \
-    && chmod +x kubectl oc \
-    && mv oc kubectl /usr/local/bin/
+  && tar -xvzf oc.tar.gz \
+  && chmod +x kubectl oc \
+  && mv oc kubectl /usr/local/bin/
 
 # Copy the go source
 COPY e2e/integration-test e2e/integration-test


### PR DESCRIPTION
This PR bumps up the go version used in the e2e dockerfile